### PR TITLE
Heroku Friendliness

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node server.js

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
     "node": "4.x"
   },
   "scripts": {
+    "postinstall": "npm run clean; npm run build;",
     "build": "NODE_ENV=production webpack -p",
     "clean": "rimraf dist",
     "cover": "istanbul cover _mocha -- --opts ./mocha.opts src/**/*.test.js",
     "dev": "node server.js",
     "lint": "eslint .",
-    "start": "npm run clean; npm run build; node server.js",
     "test": "npm run lint; mocha --opts ./mocha.opts src/**/*.test.js",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "start": "NODE_ENV=production node server.js"
   },
   "keywords": [
     "react",
@@ -66,6 +67,7 @@
     "source-map-loader": "^0.1.5",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.6",
-    "webpack": "^1.12.2"
+    "webpack": "^1.12.2",
+    "winston": "^2.1.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,15 +3,17 @@
 const path = require('path');
 const express = require('express');
 const webpack = require('webpack');
+const winston = require('winston');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const DOMAIN = '0.0.0.0';
 
 const config = require('./webpack.config');
 const compiler = webpack(config);
 
 if (process.env.NODE_ENV !== 'production') {
-  console.log('Bundling webpack... Please wait.');
+  winston.info('Bundling webpack... Please wait.');
 
   app.use(require('webpack-dev-middleware')(compiler, {
     publicPath: config.output.publicPath,
@@ -28,9 +30,9 @@ app.get('/', (req, res) => {
 
 app.listen(PORT, (err) => {
   if (err) {
-    console.log(err);
+    winston.error(err);
     return;
   }
 
-  console.log(`Listening at http://localhost:${ PORT }`);
+  winston.info(`Listening at http://${ DOMAIN }:${ PORT }`);
 });


### PR DESCRIPTION
- Added procfile
- Adjusted package.json scripts:  don't rebuild on restart: do it on postinstall instead
- Npm start should use production mode
- Listen to 0.0.0.0 instead of localhost, which Heroku can't handle.

Also added winston for server-side logging instead of using console.log.