### PR TITLE
modified npm script for test:watch, and added React test utils

### DIFF
--- a/mocha.opts
+++ b/mocha.opts
@@ -1,2 +1,1 @@
---recursive
 --compilers js:babel-core/register

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "postinstall": "npm run clean; npm run build;",
     "build": "NODE_ENV=production webpack -p",
     "clean": "rimraf dist",
-    "cover": "istanbul cover _mocha -- --opts ./mocha.opts src/**/*.test.js",
+    "cover": "istanbul cover _mocha -- --opts ./mocha.opts 'src/**/*.test.js'",
     "dev": "node server.js",
     "lint": "eslint .",
-    "test": "npm run lint && mocha --opts ./mocha.opts src/**/*.test.js",
-    "test:watch": "npm run test -- --watch",
+    "test": "npm run lint && mocha --opts ./mocha.opts 'src/**/*.test.js'",
+    "test:watch": "mocha --opts ./mocha.opts 'src/**/*.test.js' --watch",
     "start": "NODE_ENV=production node server.js"
   },
   "keywords": [
@@ -53,6 +53,7 @@
     "postcss-loader": "^0.8.0",
     "radium": "^0.14.3",
     "react": "^0.14.2",
+    "react-addons-test-utils": "^0.14.3",
     "react-dom": "^0.14.2",
     "react-hot-loader": "^1.3.0",
     "react-redux": "^4.0.0",

--- a/src/components/ui/Modal.test.js
+++ b/src/components/ui/Modal.test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import jsdom from 'jsdom';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Modal from './Modal';
+
+describe('Modal Component', () => {
+  beforeEach(() => {
+    global.document = jsdom.jsdom();
+    global.window = document.defaultView;
+  });
+
+  it('should create a modal', () => {
+    const props = {
+      children: 'hello world',
+    };
+
+    const node = document.createElement('div');
+    const modal = ReactDOM.render(<div><Modal { ...props } /></div>, node);
+
+    assert(modal.childNodes[0].innerHTML === 'hello world');
+  });
+});
+


### PR DESCRIPTION
- `npm run lint` is causing issues when running it alongside `mocha --watch`
- mocha glob patterns need to be in single quotes (See https://github.com/mochajs/mochajs.github.io/issues/8)
- Removed recursive flag from mocha
- Added dumb test as an example